### PR TITLE
fix: Update GKE node pool version for CVE-2024-53164

### DIFF
--- a/modules/gke/vulnerable_cluster.tf
+++ b/modules/gke/vulnerable_cluster.tf
@@ -93,7 +93,7 @@ resource "google_container_node_pool" "vulnerable_node_pool" {
   }
 
   # Explicitly set the version for the node pool
-  version = "1.31.4-gke.1372000"
+  version = "1.31.6-gke.1064000" # Updated to recommended version for CVE-2024-53164 remediation
 }
 
 # Outputs (optional)
@@ -108,4 +108,4 @@ output "cluster_ca_certificate" {
 
 output "node_pool_version" {
   value = google_container_node_pool.vulnerable_node_pool.version
-} 
+}


### PR DESCRIPTION
This pull request updates the GKE node pool version for the `vulnerable-gke-cluster` module.

**Reason for Change:**

Security Command Center identified a HIGH severity vulnerability (CVE-2024-53164) affecting the cluster's node pool (`vulnerable-node-pool`). This vulnerability allows for potential privilege escalation on Container-Optimized OS nodes.

**Remediation:**

The recommended remediation is to upgrade the node pool to version `1.31.6-gke.1064000` or later.
This PR updates the `version` attribute in `modules/gke/vulnerable_cluster.tf` accordingly.

See finding details:
- Category: `GKE_SECURITY_BULLETIN`
- Resource: `//container.googleapis.com/projects/cpt-poc-1/locations/us-central1/clusters/vulnerable-gke-cluster`