### PR TITLE
fix: Update GKE node pool version for CVE-2024-53164

### DIFF
--- a/modules/gke/vulnerable_cluster.tf
+++ b/modules/gke/vulnerable_cluster.tf
@@ -92,8 +92,8 @@ resource "google_container_node_pool" "vulnerable_node_pool" {
     ]
   }
 
-  # Explicitly set the version for the node pool
-  version = "1.31.4-gke.1372000"
+  # Explicitly set the version for the node pool (Updated to remediate CVE-2024-53164 / GCP-2025-012-cos)
+  version = "1.31.6-gke.1064000"
 }
 
 # Outputs (optional)
@@ -108,4 +108,4 @@ output "cluster_ca_certificate" {
 
 output "node_pool_version" {
   value = google_container_node_pool.vulnerable_node_pool.version
-} 
+}


### PR DESCRIPTION
This PR updates the GKE node pool version in `modules/gke/vulnerable_cluster.tf` from `1.31.4-gke.1372000` to `1.31.6-gke.1064000`.

This change remediates the HIGH severity vulnerability CVE-2024-53164 (GCP-2025-012-cos) identified by Security Command Center, which can lead to privilege escalation on Container-Optimized OS nodes.